### PR TITLE
Adapt parallel chunking algorithm to number of workers in BPPARAM

### DIFF
--- a/R/fitMixedModelDE.R
+++ b/R/fitMixedModelDE.R
@@ -716,7 +716,7 @@ dream <- function( exprObj, formula, data, L, ddf = c("Satterthwaite", "Kenward-
 		# Evaluate function
 		####################
 
-		it = iterBatch(exprObjMat, weightsMatrix, useWeights, n_chunks = 100)
+		it = iterBatch(exprObjMat, weightsMatrix, useWeights, n_chunks = 100, BPPARAM = BPPARAM)
 
 		if( !quiet ) message(paste0("Dividing work into ",attr(it, "n_chunks")," chunks..."))
 

--- a/R/fitModels.R
+++ b/R/fitModels.R
@@ -264,7 +264,7 @@ setGeneric("fitVarPartModel", signature="exprObj",
 		# Evaluate function
 		###################
 		
-		it = iterBatch(exprObj, weightsMatrix, useWeights, n_chunks = 100)
+		it = iterBatch(exprObj, weightsMatrix, useWeights, n_chunks = 100, BPPARAM = BPPARAM)
 		
 		if( !quiet ) message(paste0("Dividing work into ",attr(it, "n_chunks")," chunks..."))
 
@@ -562,7 +562,7 @@ setGeneric("fitExtractVarPartModel", signature="exprObj",
 		# Evaluate function
 		####################
 
-		it = iterBatch(exprObj, weightsMatrix, useWeights, n_chunks = 100)
+		it = iterBatch(exprObj, weightsMatrix, useWeights, n_chunks = 100, BPPARAM = BPPARAM)
 
 		if( !quiet) message(paste0("Dividing work into ",attr(it, "n_chunks")," chunks..."))
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -120,6 +120,9 @@ iterBatch <- function(exprObj, weights, useWeights = TRUE, scale=TRUE, n_chunks 
     # Don't split into chunks smaller than min_chunk_size
     max_allowed_chunks <- floor(nrow(exprObj) / min_chunk_size)
 	n_chunks = min(n_chunks, max_allowed_chunks)
+    # Make sure we have at least 1 chunk (since we can get 0 if
+    # min_chunk_size > nrow)
+    n_chunks <- max(n_chunks, 1)
 
 	# specify chunks
     idx <- parallel::splitIndices(nrow(exprObj), min(nrow(exprObj), n_chunks))


### PR DESCRIPTION
Now the number of chunks should always be an exact multiple of the number of workers, if that number is available.

Note that I've chosen to adjust the number of workers *upward* to the next smallest multiple of the number of workers. So for example, if n_workers = 60, then the number of chunks will be 120. This also means that if n_workers is greater over 100, then n_chunks will just be set to n_workers, no matter how large that may be. It might make more sense instead to adjust the number of chunks *downward* to the largest multiple of n_workers less than or equal to 100. But in that case you need to add a special case for n_workers > 100, in which you just set n_chunks to 100, since otherwise the largest multiple would be 0.

Lastly, I've also adjusted the logic for avoiding excessive splitting of small objects by enforcing a minimum chunk size and adjusting n_chunks accordingly, instead of just setting n_chunks to 1 if the object is small enough. For example, with min_chunk_size = 20 and nrow = 100, n_chunks will be capped at 5, regardless of all other options. I've set min_chunksize to 20, but that's an arbitrary and untested choice, so if you have a better intuition for this, feel free to change it.