### PR TITLE
Improvements to parallelization and related issues

### DIFF
--- a/R/fitMixedModelDE.R
+++ b/R/fitMixedModelDE.R
@@ -243,7 +243,7 @@ getContrast = function( exprObj, formula, data, coefficient){
 
 	mesg <- "No random effects terms specified in formula"
 	method = ''
-	if( inherits(possibleError, "error") && identical(possibleError$message, mesg) ){
+	if( isTRUE(inherits(possibleError, "error") && identical(possibleError$message, mesg)) ){
 		
 		design = model.matrix( formula, data)
 
@@ -251,12 +251,12 @@ getContrast = function( exprObj, formula, data, coefficient){
 		names(L) = colnames(design)
 
 		 # detect error when variable in formula does not exist
-	}else if( inherits(possibleError, "error") && length( grep("object '.*' not found", possibleError$message)) > 0 ){
+	}else if( isTRUE(inherits(possibleError, "error") && length( grep("object '.*' not found", possibleError$message)) > 0) ){
 		stop("Variable in formula is not found: ", gsub("object '(.*)' not found", "\\1", possibleError$message) )
 	}
 	else{
 
-		if( inherits(possibleError, "error") && grep('the fixed-effects model matrix is column rank deficient', possibleError$message) == 1 ){
+		if( isTRUE(inherits(possibleError, "error") && grep('the fixed-effects model matrix is column rank deficient', possibleError$message) == 1) ){
 			stop(paste(possibleError$message, "\n\nSuggestion: rescale fixed effect variables.\nThis will not change the variance fractions or p-values."))
 		} 		
 

--- a/R/fitMixedModelDE.R
+++ b/R/fitMixedModelDE.R
@@ -719,7 +719,7 @@ dream <- function( exprObj, formula, data, L, ddf = c("Satterthwaite", "Kenward-
 		# Evaluate function
 		####################
 
-		it = iterBatch(exprObjMat, weightsMatrix, useWeights, n_chunks = 100)
+		it = iterBatch(exprObjMat, weightsMatrix, useWeights, n_chunks = 100, BPPARAM = BPPARAM)
 
 		if( !quiet ) message(paste0("Dividing work into ",attr(it, "n_chunks")," chunks..."))
 

--- a/R/fitMixedModelDE.R
+++ b/R/fitMixedModelDE.R
@@ -730,7 +730,7 @@ dream <- function( exprObj, formula, data, L, ddf = c("Satterthwaite", "Kenward-
 		
 		names(resList) = seq_len(length(resList))
 
-		if( !quiet ) message("\nTotal:", paste(format((proc.time() - timeStart)[3], digits=0), "s"))		
+		if( !quiet ) message("\nTotal:", paste(format((proc.time() - timeStart)[3], digits = 0, scientific = FALSE), "s"))
 
 		x = 1
 		# extract results

--- a/R/fitMixedModelDE.R
+++ b/R/fitMixedModelDE.R
@@ -723,11 +723,9 @@ dream <- function( exprObj, formula, data, L, ddf = c("Satterthwaite", "Kenward-
 
 		if( !quiet ) message(paste0("Dividing work into ",attr(it, "n_chunks")," chunks..."))
 
-		resList <- bpiterate( it, .eval_master, 
+		resList <- do.call(c, bpiterate( it, .eval_master,
 			data2=data2, form=form, REML=REML, theta=fitInit@theta, control=control,..., 
-			 REDUCE=c,
-		    reduce.in.order=TRUE,	
-			BPPARAM=BPPARAM)
+			BPPARAM=BPPARAM))
 	
 		
 		names(resList) = seq_len(length(resList))

--- a/R/fitModels.R
+++ b/R/fitModels.R
@@ -281,7 +281,7 @@ setGeneric("fitVarPartModel", signature="exprObj",
 	}
 
 	# pb$update( responsePlaceholder$max_iter / responsePlaceholder$max_iter )
-	if( !quiet ) message("\nTotal:", paste(format((proc.time() - timeStart)[3], digits=0), "s"))		
+	if( !quiet ) message("\nTotal:", paste(format((proc.time() - timeStart)[3], digits = 0, scientific = FALSE), "s"))
 	# set name of each entry
 	names(res) <- rownames( exprObj )
 
@@ -571,7 +571,7 @@ setGeneric("fitExtractVarPartModel", signature="exprObj",
 		modelType = "linear mixed model"
 	}
 
-	message("\nTotal:", paste(format((proc.time() - timeStart)[3], digits=0), "s"))		
+	message("\nTotal:", paste(format((proc.time() - timeStart)[3], digits = 0, scientific = FALSE), "s"))
 
 	varPartMat <- data.frame(matrix(unlist(varPart), nrow=length(varPart), byrow=TRUE))
 	colnames(varPartMat) <- names(varPart[[1]])

--- a/R/fitModels.R
+++ b/R/fitModels.R
@@ -195,7 +195,7 @@ setGeneric("fitVarPartModel", signature="exprObj",
 
 	mesg <- "No random effects terms specified in formula"
 	method = ''
-	if( inherits(possibleError, "error") && identical(possibleError$message, mesg) ){
+	if( isTRUE(inherits(possibleError, "error") && identical(possibleError$message, mesg)) ){
 
 		# fit the model for testing
 		fit <- lm( eval(parse(text=form)), data=data,...)
@@ -215,7 +215,7 @@ setGeneric("fitVarPartModel", signature="exprObj",
 
 	}else{
 
-		if( inherits(possibleError, "error") &&  grep('the fixed-effects model matrix is column rank deficient', possibleError$message) == 1 ){
+		if( isTRUE(inherits(possibleError, "error") &&  grep('the fixed-effects model matrix is column rank deficient', possibleError$message) == 1) ){
 			stop(paste(possibleError$message, "\n\nSuggestion: rescale fixed effect variables.\nThis will not change the variance fractions or p-values."))
 		} 
 

--- a/R/fitModels.R
+++ b/R/fitModels.R
@@ -264,7 +264,7 @@ setGeneric("fitVarPartModel", signature="exprObj",
 		# Evaluate function
 		###################
 		
-		it = iterBatch(exprObj, weightsMatrix, useWeights, n_chunks = 100)
+		it = iterBatch(exprObj, weightsMatrix, useWeights, n_chunks = 100, BPPARAM = BPPARAM)
 		
 		if( !quiet ) message(paste0("Dividing work into ",attr(it, "n_chunks")," chunks..."))
 
@@ -560,7 +560,7 @@ setGeneric("fitExtractVarPartModel", signature="exprObj",
 		# Evaluate function
 		####################
 
-		it = iterBatch(exprObj, weightsMatrix, useWeights, n_chunks = 100)
+		it = iterBatch(exprObj, weightsMatrix, useWeights, n_chunks = 100, BPPARAM = BPPARAM)
 
 		if( !quiet) message(paste0("Dividing work into ",attr(it, "n_chunks")," chunks..."))
 

--- a/R/fitModels.R
+++ b/R/fitModels.R
@@ -268,11 +268,9 @@ setGeneric("fitVarPartModel", signature="exprObj",
 		
 		if( !quiet ) message(paste0("Dividing work into ",attr(it, "n_chunks")," chunks..."))
 
-		res <- bpiterate( it, .eval_master, 
+		res <- do.call(c, bpiterate( it, .eval_master,
 			data2=data2, form=form, REML=REML, theta=fitInit@theta, fxn=fxn, control=control,..., 
-			 REDUCE=c,
-		    reduce.in.order=TRUE,	
-			BPPARAM=BPPARAM)	
+			BPPARAM=BPPARAM))
 
 		# if there is an error in evaluating fxn (usually in parallel backend)
 		if( is(res, 'remote_error') ){
@@ -566,11 +564,9 @@ setGeneric("fitExtractVarPartModel", signature="exprObj",
 
 		if( !quiet) message(paste0("Dividing work into ",attr(it, "n_chunks")," chunks..."))
 
-		varPart <- bpiterate( it, .eval_master, 
+		varPart <- do.call(c, bpiterate( it, .eval_master,
 			data=data, form=form, REML=REML, theta=fitInit@theta, control=control,..., 
-			 REDUCE=c,
-		    reduce.in.order=TRUE,	
-			BPPARAM=BPPARAM)
+			BPPARAM=BPPARAM))
 
 		modelType = "linear mixed model"
 	}

--- a/R/misc.R
+++ b/R/misc.R
@@ -106,10 +106,27 @@ exprIter = function( exprObj, weights, useWeights = TRUE, scale=TRUE, iterCount 
 # }
 
 
-iterBatch <- function(exprObj, weights, useWeights = TRUE, scale=TRUE, n_chunks = nrow(exprObj) / 500 ) {
+iterBatch <- function(exprObj, weights, useWeights = TRUE, scale=TRUE, n_chunks = nrow(exprObj) / 500, min_chunk_size = 20, BPPARAM = NULL ) {
+    # Adjust number of chunks upward to the next multiple of number of
+    # workers in BPPARAM, if this can be determined. If any errors are
+    # encountered, just continue without adjusting.
+    tryCatch(
+        if (is(BPPARAM, "BiocParallelParam")) {
+            n_workers <- bpworkers(BPPARAM)
+            if (!is.null(n_workers) && is.numeric(n_workers) && n_workers >= 1) {
+                chunks_per_worker <- ceiling(n_chunks / n_workers)
+                n_chunks <- chunks_per_worker * n_workers
+            }
+        },
+        error = function(...) NULL
+    )
 
-	# if there are fewer rows than chuncks, set n_chunks=1
-	n_chunks = ifelse( nrow(exprObj) >= n_chunks, n_chunks, 1)
+    # Don't split into chunks smaller than min_chunk_size
+    max_allowed_chunks <- floor(nrow(exprObj) / min_chunk_size)
+	n_chunks = min(n_chunks, max_allowed_chunks)
+    # Make sure we have at least 1 chunk (since we can get 0 if
+    # min_chunk_size > nrow)
+    n_chunks <- max(n_chunks, 1)
 
 	# specify chunks
     idx <- parallel::splitIndices(nrow(exprObj), min(nrow(exprObj), n_chunks))

--- a/R/misc.R
+++ b/R/misc.R
@@ -514,7 +514,7 @@ colinearityScore = function(fit){
 .isDisconnected = function(){
 	i = NULL
 	possibleError <- tryCatch( suppressWarnings(foreach(i = seq_len(2)) %dopar% {i}), error = function(e) e)
-	return( inherits(possibleError, "error") && identical(possibleError$message, "invalid connection") )
+	return( isTRUE(inherits(possibleError, "error") && identical(possibleError$message, "invalid connection")) )
 }
 
 


### PR DESCRIPTION
With the changes in d36ff29, the number of chunks should now always be an exact multiple of the number of workers, if that number is available.

Note that I've chosen to adjust the number of workers upward to the next smallest multiple of the number of workers. So for example, if n_workers = 60, then the number of chunks will be 120. This also means that if n_workers is greater over 100, then n_chunks will just be set to n_workers, no matter how large that may be. It might make more sense instead to adjust the number of chunks downward to the largest multiple of n_workers less than or equal to 100. But in that case you need to add a special case for n_workers > 100, in which you just set n_chunks to 100, since otherwise the largest multiple would be 0.

Another note: I'm not sure if you chose 100 chunks for reasons relating to memory usage or other concerns, which I why I implemented things as described above. However, it might make sense to simply always set n_chunks = n_workers whenever n_workers is available. Obviously, the code for that would be much simpler, and I'd be happy to implement that if you think it would be better.

Lastly, I've also adjusted the logic for avoiding excessive splitting of small objects by enforcing a minimum chunk size and adjusting n_chunks accordingly, instead of just setting n_chunks to 1 if the object is small enough. For example, with min_chunk_size = 20 and nrow = 100, n_chunks will be capped at 5, regardless of all other options. I've set min_chunksize to 20, but that's an arbitrary and untested choice, so if you have a better intuition for this, feel free to change it.

As for the other commits:

* 1c67bba makes the post-parallelization aggregation process a good bit faster by only calling the aggregation function once.
* 6b7fa04 fixes #26 by using `isTRUE` within if statements to ensure that conditionals never evaluate to NA.