### PR TITLE
Account for bpiterate returning a list of remote_error objects

### DIFF
--- a/R/fitModels.R
+++ b/R/fitModels.R
@@ -207,7 +207,7 @@ setGeneric("fitVarPartModel", signature="exprObj",
 		# check that model fit is valid, and throw warning if not
 		checkModelStatus( fit, showWarnings=showWarnings, colinearityCutoff=colinearityCutoff )
 
-		res <- foreach(responsePlaceholder=exprIter(exprObj, weightsMatrix, useWeights), .packages=c("splines","lme4") ) %do% {
+		resList <- foreach(responsePlaceholder=exprIter(exprObj, weightsMatrix, useWeights), .packages=c("splines","lme4") ) %do% {
 			# fit linear mixed model
 			fit = lm( eval(parse(text=form)), data=data, weights=responsePlaceholder$weights,na.action=stats::na.exclude,...)
 
@@ -295,9 +295,9 @@ setGeneric("fitVarPartModel", signature="exprObj",
 	# pb$update( responsePlaceholder$max_iter / responsePlaceholder$max_iter )
 	if( !quiet ) message("\nTotal:", paste(format((proc.time() - timeStart)[3], digits = 0, scientific = FALSE), "s"))
 	# set name of each entry
-	names(res) <- rownames( exprObj )
+	names(resList) <- rownames( exprObj )
 
- 	new( "VarParFitList", res, method=method )
+ 	new( "VarParFitList", resList, method=method )
 }
 
 ## matrix


### PR DESCRIPTION
Apparently bpiterate can sometimes return a list, but one or more elements of the list is a remote error object. The code now checks for this case.

I believe this error case was probably introduced by my previous pull request (#27), which removed the use of the `REDUCE` argument to `bpiterate` as part of an optimization. This pull request now properly handles the case my code introduced.