### PR TITLE
Overhaul of contrast code

### DIFF
--- a/R/fitMixedModelDE.R
+++ b/R/fitMixedModelDE.R
@@ -168,6 +168,13 @@ getContrast = function( exprObj, formula, data, coefficient){
 	L
 }
 
+#' @importFrom lme4 nobars
+.getFixefNames = function( formula, data, ... ) {
+  ## See lme4::lFormula
+  formula[[length(formula)]] <- nobars(formula[[length(formula)]])
+  colnames(model.matrix(object = formula, data = data, ...))
+}
+
 #' Get all univariate contrasts
 #'
 #' Get all univariate contrasts
@@ -180,27 +187,16 @@ getContrast = function( exprObj, formula, data, coefficient){
 #'  Matrix testing each variable one at a time.  Contrasts are on rows
 #'
 #' @keywords internal
-.getAllUniContrasts = function( exprObj, formula, data){ 
-
-	Linit = .getContrastInit( exprObj, formula, data)
-
-	Lall = lapply( seq_len(length(Linit)), function(i){
-		Linit[i] = 1
-		Linit
-		})
-	names(Lall) = names(Linit)
-	Lall = do.call("rbind", Lall)
-
-	# remove intercept contrasts
-	# Lall[,-1,drop=FALSE]
-	Lall
-}
-
-#' @importFrom lme4 nobars
-.getFixefNames = function( formula, data, ... ) {
-  ## See lme4::lFormula
-  formula[[length(formula)]] <- nobars(formula[[length(formula)]])
-  colnames(model.matrix(object = formula, data = data, ...))
+.getAllUniContrasts = function( exprObj, formula, data){
+  fixef_names <- .getFixefNames(formula, data)
+  ## For large designs, might be worth using Matrix::Diagonal to make
+  ## a sparse diagonal matrix
+  L <- diag(x = 1, nrow = length(fixef_names))
+  dimnames(L) <- list(
+    Levels = fixef_names,
+    Contrasts = fixef_names
+  )
+  L
 }
 
 .getContrastInit = function( exprObj, formula, data ){

--- a/R/isRunableFormula.R
+++ b/R/isRunableFormula.R
@@ -9,20 +9,20 @@
 #' @param formula formula
 #' @param data data
 #'
+#' @importFrom lme4 lFormula lmerControl
 #' @export
 isRunableFormula = function( exprObj, formula, data){ 
 
-	isRunable = TRUE
-
-	possibleError <- tryCatch( 
-		# variancePartition:::.getContrastInit(res$geneExpr$E, form_mod, data[colnames(res$geneExpr),])
-		.getContrastInit(exprObj, formula, data)
-		, error = function(e) e)
-
-	mesg <- "the fixed-effects model matrix is column rank deficient"
-	if( isTRUE(inherits(possibleError, "error") && grep(mesg, possibleError$message) == 1) ){
-		isRunable = FALSE
-	}
-
-	isRunable
+  isRunable <- TRUE
+  tryCatch(
+    control <- lmerControl(check.rankX="stop.deficient")
+    lFormula( formula = formula, data = data, control = control ),
+    error = function(e) {
+      mesg <- "the fixed-effects model matrix is column rank deficient"
+      if (any(grepl(mesg, e$message))) {
+        isRunable <<- FALSE
+      }
+    }
+  )
+  isRunable
 }


### PR DESCRIPTION
I have reimplemented the various contrast functions (`getContrast`, `.getContrastInit`, etc.) as well as added a new function `makeContrastsDream`, which is designed to work like `limma::makeContrasts`. Note that since `.getContrastInit` no longer actually runs `lmer`, it no longer throws errors for things like rank-deficient designs. If this is undesirable, I can add those checks back in.

I still need to add documentation and do some testing before this is ready to merge, but I'm putting it up now so you can look at it.