### PR TITLE
Allow contrasts to be specified in ... for makeContrastsDream

### DIFF
--- a/R/contrasts.R
+++ b/R/contrasts.R
@@ -122,14 +122,10 @@ getContrast = function( exprObj, formula, data, coefficient){
 #' @importFrom rlang new_environment eval_tidy caller_env
 #' @export
 makeContrastsDream = function(formula, data, ..., contrasts=NULL){
-	if( is.null(contrasts) ){
-		stop("Specify constrasts")
-	}
-  coef_names <- .getFixefNames( formula, data)
   e <- .getContrastExpressions(..., contrasts = contrasts)
-  if (length(e) == 0) {
-      stop("Need at least one contrast")
-  }
+	if( length(e) == 0 ){
+		stop("Must specify at least one contrast")
+	}
   L_uni <- .getAllUniContrasts(formula, data)
   L_uni_env <- new_environment(
     c(asplit(L_uni, 2)),


### PR DESCRIPTION
This matches the interface of `limma::makeContrasts`, which can accept contrasts as individual named arguments or in a list as the contrasts argument. The code still verifies that at least one contrast was specified via either means. So the following are equivalent:

```R
L = makeContrastsDream( form, info, contrasts = c(Batch1_vs_2 = "Batch1 - Batch2", Batch3_vs_4 = "Batch3 - Batch4", Batch1_vs_34 = "Batch1 - (Batch3 + Batch4)/2"))
L = makeContrastsDream(
    form, 
    info, 
    Batch1_vs_2 = "Batch1 - Batch2", 
    Batch3_vs_4 = "Batch3 - Batch4", 
    Batch1_vs_34 = "Batch1 - (Batch3 + Batch4)/2"
)
```

(This is unrelated to any of the other potential issues we discussed. It's just one that I found while testing.)