### PR TITLE
Allow makeContrastsDream to accept string literal contrasts in ...

### DIFF
--- a/R/contrasts.R
+++ b/R/contrasts.R
@@ -147,6 +147,13 @@ makeContrastsDream = function(formula, data, ..., contrasts=NULL){
     e <- lapply(as.character(unlist(contrasts)), parse_expr)
     names(e) <- names(unlist(contrasts))
   }
+  # Allow contrasts to be specified as string literals in addition to
+  # unquoted expressions.
+  for (i in seq_along(e)) {
+    if (is.character(e[[i]])) {
+      e[[i]] <- parse_expr(e[[i]])
+    }
+  }
   e_text <- vapply(e, deparse1, character(1))
   if (is.null(names(e))) {
     names(e) <- e_text


### PR DESCRIPTION
Now all of the following work and produce the same result:

```
library(variancePartition)
data(varPartData)
form <- ~ 0 + Batch + (1|Individual) + (1|Tissue) 
L = makeContrastsDream(form, info, B = "Batch2 - Batch3") # This is the one that failed before
L = makeContrastsDream(form, info, B = Batch2 - Batch3)
L = makeContrastsDream(form, info, contrasts = list(B = "Batch2 - Batch3"))
```